### PR TITLE
Améliore l'analyse des commandes de trading

### DIFF
--- a/microserveur/command_parser.py
+++ b/microserveur/command_parser.py
@@ -1,0 +1,180 @@
+"""Parsing helpers to convert text commands into Binance orders."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Optional
+
+
+@dataclass
+class ParsedOrder:
+    side: str
+    symbol: str
+    order_type: str
+    quantity: str
+    price: Optional[str] = None
+    time_in_force: Optional[str] = None
+
+    def dict(self) -> dict[str, Optional[str]]:
+        return asdict(self)
+
+    def model_dump(self) -> dict[str, Optional[str]]:
+        return self.dict()
+
+
+class CommandParsingError(Exception):
+    """Raised when a free-form command cannot be understood."""
+
+
+RAW_SIDE_KEYWORDS = {
+    "buy": "BUY",
+    "sell": "SELL",
+    "acheter": "BUY",
+    "achete": "BUY",
+    "achète": "BUY",
+    "achetez": "BUY",
+    "achetons": "BUY",
+    "vendre": "SELL",
+    "vend": "SELL",
+    "vends": "SELL",
+    "vendez": "SELL",
+}
+
+RAW_ORDER_TYPE_KEYWORDS = {
+    "market": "MARKET",
+    "marche": "MARKET",
+    "marché": "MARKET",
+    "limit": "LIMIT",
+    "limite": "LIMIT",
+}
+
+
+def strip_accents(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def normalize_keyword(token: str) -> str:
+    stripped = strip_accents(token).lower()
+    return re.sub(r"[^a-z0-9]", "", stripped)
+
+
+SIDE_KEYWORDS = {normalize_keyword(key): value for key, value in RAW_SIDE_KEYWORDS.items()}
+ORDER_TYPE_KEYWORDS = {
+    normalize_keyword(key): value for key, value in RAW_ORDER_TYPE_KEYWORDS.items()
+}
+
+ORDER_KEYWORDS = set(SIDE_KEYWORDS.keys()) | set(ORDER_TYPE_KEYWORDS.keys())
+
+
+def decimal_to_str(value: Decimal) -> str:
+    quantized = value.normalize()
+    as_str = format(quantized, "f")
+    if "." in as_str:
+        as_str = as_str.rstrip("0").rstrip(".")
+    return as_str or "0"
+
+
+NUMBER_PATTERN = re.compile(r"(?<![A-Za-z0-9])[+-]?\d+(?:[.,]\d+)?(?![A-Za-z0-9])")
+
+
+def extract_numbers(tokens: list[str]) -> list[Decimal]:
+    numbers = []
+    for token in tokens:
+        for match in NUMBER_PATTERN.finditer(token):
+            normalized = match.group().replace(",", ".")
+            try:
+                numbers.append(Decimal(normalized))
+            except InvalidOperation:
+                continue
+    return numbers
+
+
+def clean_symbol_token(token: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "", strip_accents(token))
+
+
+def extract_symbol(raw_tokens: list[str], keyword_tokens: list[str]) -> Optional[str]:
+    cleaned_tokens = [clean_symbol_token(token) for token in raw_tokens]
+    for cleaned, keyword_token in zip(cleaned_tokens, keyword_tokens):
+        if not cleaned:
+            continue
+        if keyword_token in ORDER_KEYWORDS:
+            continue
+        if not any(char.isalpha() for char in cleaned):
+            continue
+        candidate = cleaned.upper()
+        if len(candidate) >= 5:
+            return candidate
+    for idx in range(len(cleaned_tokens) - 1):
+        first = cleaned_tokens[idx]
+        second = cleaned_tokens[idx + 1]
+        first_keyword = keyword_tokens[idx]
+        second_keyword = keyword_tokens[idx + 1]
+        if (
+            not first
+            or not second
+            or first_keyword in ORDER_KEYWORDS
+            or second_keyword in ORDER_KEYWORDS
+        ):
+            continue
+        if not any(char.isalpha() for char in first) or not any(char.isalpha() for char in second):
+            continue
+        if 3 <= len(first) <= 5 and 3 <= len(second) <= 5:
+            candidate = f"{first}{second}".upper()
+            if len(candidate) >= 5:
+                return candidate
+    return None
+
+
+def parse_trade_command(command: str) -> ParsedOrder:
+    raw_tokens = command.strip().split()
+    keyword_tokens = [normalize_keyword(token) for token in raw_tokens]
+
+    side = next((SIDE_KEYWORDS[token] for token in keyword_tokens if token in SIDE_KEYWORDS), None)
+    if not side:
+        raise CommandParsingError("Impossible de déterminer si l'ordre est un achat ou une vente.")
+
+    order_type = next(
+        (ORDER_TYPE_KEYWORDS[token] for token in keyword_tokens if token in ORDER_TYPE_KEYWORDS),
+        "MARKET",
+    )
+
+    symbol = extract_symbol(raw_tokens, keyword_tokens)
+    if not symbol:
+        raise CommandParsingError("Impossible de déterminer le symbole à trader.")
+
+    numbers = extract_numbers(raw_tokens)
+    if not numbers:
+        raise CommandParsingError("Impossible de déterminer la quantité à trader.")
+
+    quantity = numbers[0]
+    if quantity <= 0:
+        raise CommandParsingError("La quantité doit être supérieure à zéro.")
+
+    price: Optional[Decimal] = None
+    if order_type == "LIMIT":
+        if len(numbers) < 2:
+            raise CommandParsingError("Une commande limite nécessite un prix.")
+        price = numbers[1]
+        if price <= 0:
+            raise CommandParsingError("Le prix doit être supérieur à zéro.")
+
+    return ParsedOrder(
+        side=side,
+        symbol=symbol,
+        order_type=order_type,
+        quantity=decimal_to_str(quantity),
+        price=decimal_to_str(price) if price is not None else None,
+        time_in_force="GTC" if order_type == "LIMIT" else None,
+    )
+
+
+__all__ = [
+    "CommandParsingError",
+    "ParsedOrder",
+    "parse_trade_command",
+]

--- a/microserveur/input.py
+++ b/microserveur/input.py
@@ -1,4 +1,5 @@
-from main import CommandParsingError, attendre_commande, parse_trade_command
+from command_parser import CommandParsingError, parse_trade_command
+from main import attendre_commande
 
 
 def main() -> None:

--- a/microserveur/tests/test_parser.py
+++ b/microserveur/tests/test_parser.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        (
+            "Achète 0,1 BTCUSDT au marché",
+            ParsedOrder(
+                side="BUY",
+                symbol="BTCUSDT",
+                order_type="MARKET",
+                quantity="0.1",
+            ),
+        ),
+        (
+            "Vend 2 eth usdt limit à 2300",
+            ParsedOrder(
+                side="SELL",
+                symbol="ETHUSDT",
+                order_type="LIMIT",
+                quantity="2",
+                price="2300",
+                time_in_force="GTC",
+            ),
+        ),
+        (
+            "achetez 5 sol usdt",
+            ParsedOrder(
+                side="BUY",
+                symbol="SOLUSDT",
+                order_type="MARKET",
+                quantity="5",
+            ),
+        ),
+    ],
+)
+def test_parse_trade_command_success(command: str, expected: ParsedOrder) -> None:
+    parsed = parse_trade_command(command)
+    assert parsed.model_dump() == expected.model_dump()
+
+
+def test_parse_trade_command_requires_symbol() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("achète 1 au marché")
+
+
+def test_parse_trade_command_rejects_negative_quantity() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("acheter -1 btcusdt")
+
+
+def test_parse_trade_command_limit_requires_price() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("vendre 2 eth usdt limit")


### PR DESCRIPTION
## Summary
- isole la logique de parsing des ordres dans `command_parser.py` avec normalisation des mots-clés (accents, conjugaisons) et extraction renforcée des symboles et quantités
- met à jour l'API FastAPI et le script CLI pour s'appuyer sur ce parseur factorisé
- ajoute une suite de tests `pytest` couvrant des exemples de commandes réussies et des cas d'erreur

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1933d30b48328be8177f16a4ea631