### PR TITLE
Adjust symbol extraction to accept varied base lengths

### DIFF
--- a/microserveur/command_parser.py
+++ b/microserveur/command_parser.py
@@ -69,6 +69,33 @@ ORDER_TYPE_KEYWORDS = {
 
 ORDER_KEYWORDS = set(SIDE_KEYWORDS.keys()) | set(ORDER_TYPE_KEYWORDS.keys())
 
+KNOWN_SYMBOL_SUFFIXES = {
+    "USDT",
+    "USDC",
+    "BUSD",
+    "TUSD",
+    "FDUSD",
+    "DAI",
+    "BTC",
+    "ETH",
+    "BNB",
+    "BIDR",
+    "EUR",
+    "GBP",
+    "TRY",
+    "BRL",
+    "AUD",
+    "PAXG",
+}
+
+
+def is_valid_candidate(candidate: str) -> bool:
+    return (
+        len(candidate) >= 5
+        and candidate.isalnum()
+        and any(candidate.endswith(suffix) for suffix in KNOWN_SYMBOL_SUFFIXES)
+    )
+
 
 def decimal_to_str(value: Decimal) -> str:
     quantized = value.normalize()
@@ -107,7 +134,7 @@ def extract_symbol(raw_tokens: list[str], keyword_tokens: list[str]) -> Optional
         if not any(char.isalpha() for char in cleaned):
             continue
         candidate = cleaned.upper()
-        if len(candidate) >= 5:
+        if is_valid_candidate(candidate):
             return candidate
     for idx in range(len(cleaned_tokens) - 1):
         first = cleaned_tokens[idx]
@@ -123,10 +150,9 @@ def extract_symbol(raw_tokens: list[str], keyword_tokens: list[str]) -> Optional
             continue
         if not any(char.isalpha() for char in first) or not any(char.isalpha() for char in second):
             continue
-        if 3 <= len(first) <= 5 and 3 <= len(second) <= 5:
-            candidate = f"{first}{second}".upper()
-            if len(candidate) >= 5:
-                return candidate
+        candidate = f"{first}{second}".upper()
+        if is_valid_candidate(candidate):
+            return candidate
     return None
 
 

--- a/microserveur/tests/test_parser.py
+++ b/microserveur/tests/test_parser.py
@@ -40,6 +40,24 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 quantity="5",
             ),
         ),
+        (
+            "achète 1 op usdt",
+            ParsedOrder(
+                side="BUY",
+                symbol="OPUSDT",
+                order_type="MARKET",
+                quantity="1",
+            ),
+        ),
+        (
+            "vend 2 santos usdt",
+            ParsedOrder(
+                side="SELL",
+                symbol="SANTOSUSDT",
+                order_type="MARKET",
+                quantity="2",
+            ),
+        ),
     ],
 )
 def test_parse_trade_command_success(command: str, expected: ParsedOrder) -> None:


### PR DESCRIPTION
## Summary
- ensure symbol extraction uses a dedicated validator instead of fixed token lengths
- add parser tests covering shorter and longer base asset names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25a3cec588328a836166eadc59d2f