### PR TITLE
Standardize responses and expose quote asset

### DIFF
--- a/microserveur/command_parser.py
+++ b/microserveur/command_parser.py
@@ -17,6 +17,7 @@ class ParsedOrder:
     quantity: str
     price: Optional[str] = None
     time_in_force: Optional[str] = None
+    quote_asset: Optional[str] = None
 
     def dict(self) -> dict[str, Optional[str]]:
         return asdict(self)
@@ -95,6 +96,13 @@ def is_valid_candidate(candidate: str) -> bool:
         and candidate.isalnum()
         and any(candidate.endswith(suffix) for suffix in KNOWN_SYMBOL_SUFFIXES)
     )
+
+
+def detect_quote_asset(symbol: str) -> Optional[str]:
+    for suffix in sorted(KNOWN_SYMBOL_SUFFIXES, key=len, reverse=True):
+        if symbol.endswith(suffix):
+            return suffix
+    return None
 
 
 def decimal_to_str(value: Decimal) -> str:
@@ -196,6 +204,7 @@ def parse_trade_command(command: str) -> ParsedOrder:
         quantity=decimal_to_str(quantity),
         price=decimal_to_str(price) if price is not None else None,
         time_in_force="GTC" if order_type == "LIMIT" else None,
+        quote_asset=detect_quote_asset(symbol),
     )
 
 

--- a/microserveur/main.py
+++ b/microserveur/main.py
@@ -1,13 +1,15 @@
 from functools import lru_cache
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Request
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from binance.client import Client
 from binance.exceptions import BinanceAPIException, BinanceRequestException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
-from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
+from command_parser import CommandParsingError, parse_trade_command
 
 
 class Settings(BaseSettings):
@@ -56,9 +58,30 @@ def attendre_commande() -> str:
 app = FastAPI()
 
 
+def success_response(message: str, data: Optional[dict] = None, status_code: int = 200) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"status": "success", "message": message, "data": data},
+    )
+
+
+def error_response(status_code: int, message: str, data: Optional[dict] = None) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"status": "error", "message": message, "data": data},
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return error_response(422, "Requête invalide.", {"errors": exc.errors()})
+
+
 @app.get("/")
 def read_root():
-    return {"status": "ready"}
+    return success_response("Service prêt.")
 
 
 @app.post("/orders")
@@ -66,7 +89,7 @@ def place_order(payload: CommandRequest):
     try:
         parsed = parse_trade_command(payload.command)
     except CommandParsingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return error_response(400, str(exc))
 
     client = create_client(payload.testnet)
     order_payload = {
@@ -77,20 +100,32 @@ def place_order(payload: CommandRequest):
     }
     if parsed.order_type == "LIMIT":
         if parsed.price is None:
-            raise HTTPException(status_code=500, detail="Le prix de l'ordre limite est manquant après l'analyse.")
+            return error_response(
+                500, "Le prix de l'ordre limite est manquant après l'analyse."
+            )
         order_payload["timeInForce"] = parsed.time_in_force or "GTC"
         order_payload["price"] = parsed.price
 
     try:
         response = client.create_order(**order_payload)
     except (BinanceAPIException, BinanceRequestException) as exc:
-        raise HTTPException(status_code=502, detail=f"Erreur Binance : {exc.message}") from exc
+        error_details = {
+            "code": getattr(exc, "code", None),
+            "message": exc.message,
+        }
+        return error_response(502, "Erreur renvoyée par Binance.", error_details)
     except Exception as exc:  # pragma: no cover - unexpected errors
-        raise HTTPException(status_code=500, detail="Erreur inattendue lors de l'envoi de l'ordre.") from exc
+        return error_response(500, "Erreur inattendue lors de l'envoi de l'ordre.")
     finally:
         try:
             client.close_connection()
         except Exception:
             pass
 
-    return {"parsed_order": parsed.dict(), "binance_response": response}
+    return success_response(
+        "Ordre transmis avec succès.",
+        {
+            "parsed_order": parsed.dict(),
+            "binance_response": response,
+        },
+    )

--- a/microserveur/tests/test_parser.py
+++ b/microserveur/tests/test_parser.py
@@ -18,6 +18,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="BTCUSDT",
                 order_type="MARKET",
                 quantity="0.1",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -29,6 +30,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 quantity="2",
                 price="2300",
                 time_in_force="GTC",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -38,6 +40,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="SOLUSDT",
                 order_type="MARKET",
                 quantity="5",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -47,6 +50,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="OPUSDT",
                 order_type="MARKET",
                 quantity="1",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -56,6 +60,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="SANTOSUSDT",
                 order_type="MARKET",
                 quantity="2",
+                quote_asset="USDT",
             ),
         ),
     ],
@@ -63,6 +68,12 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
 def test_parse_trade_command_success(command: str, expected: ParsedOrder) -> None:
     parsed = parse_trade_command(command)
     assert parsed.model_dump() == expected.model_dump()
+
+
+def test_parse_trade_command_detects_quote_with_separator() -> None:
+    parsed = parse_trade_command("acheter 1 btc/usdt")
+    assert parsed.symbol == "BTCUSDT"
+    assert parsed.quote_asset == "USDT"
 
 
 def test_parse_trade_command_requires_symbol() -> None:


### PR DESCRIPTION
## Summary
- add automatic quote asset detection when parsing trade commands, including slash-separated symbols
- expose the detected quote asset in the parsed order payload returned by the API
- standardize API responses and validation errors to use a {status, message, data} structure with clearer error details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25bc99b188328b4fa335e5691af80