### PR TITLE
Add trailing stop order support

### DIFF
--- a/microserveur/tests/test_main.py
+++ b/microserveur/tests/test_main.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import sys
+from typing import Optional
+
+import pytest
+
+pytest.importorskip("fastapi")
+TestClient = pytest.importorskip("fastapi.testclient").TestClient  # type: ignore[attr-defined]
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.last_payload: Optional[dict] = None
+
+    def create_order(self, **payload):  # type: ignore[no-untyped-def]
+        self.last_payload = payload
+        return {"orderId": 123}
+
+    def close_connection(self) -> None:
+        pass
+
+
+def test_place_trailing_order_forwards_payload(monkeypatch):
+    dummy_client = DummyClient()
+
+    def fake_create_client(use_testnet: bool) -> DummyClient:
+        assert use_testnet is True
+        return dummy_client
+
+    monkeypatch.setattr(main, "create_client", fake_create_client)
+
+    client = TestClient(main.app)
+    response = client.post(
+        "/orders",
+        json={"command": "achetez 0,25 btcusdt trailing 0,5 activation 20000", "testnet": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert dummy_client.last_payload == {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "TRAILING_STOP_MARKET",
+        "quantity": "0.25",
+        "callbackRate": "0.5",
+        "activationPrice": "20000",
+    }
+    assert body["data"]["parsed_order"]["callback_rate"] == "0.5"
+    assert body["data"]["parsed_order"]["activation_price"] == "20000"

--- a/microserveur/tests/test_parser.py
+++ b/microserveur/tests/test_parser.py
@@ -18,6 +18,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="BTCUSDT",
                 order_type="MARKET",
                 quantity="0.1",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -29,6 +30,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 quantity="2",
                 price="2300",
                 time_in_force="GTC",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -38,6 +40,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="SOLUSDT",
                 order_type="MARKET",
                 quantity="5",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -47,6 +50,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="OPUSDT",
                 order_type="MARKET",
                 quantity="1",
+                quote_asset="USDT",
             ),
         ),
         (
@@ -56,6 +60,30 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 symbol="SANTOSUSDT",
                 order_type="MARKET",
                 quantity="2",
+                quote_asset="USDT",
+            ),
+        ),
+        (
+            "achetez 0,25 btcusdt trailing 0,5 activation 20000",
+            ParsedOrder(
+                side="BUY",
+                symbol="BTCUSDT",
+                order_type="TRAILING_STOP_MARKET",
+                quantity="0.25",
+                quote_asset="USDT",
+                callback_rate="0.5",
+                activation_price="20000",
+            ),
+        ),
+        (
+            "vend 2 ethusdt suiveur 0.1",
+            ParsedOrder(
+                side="SELL",
+                symbol="ETHUSDT",
+                order_type="TRAILING_STOP_MARKET",
+                quantity="2",
+                quote_asset="USDT",
+                callback_rate="0.1",
             ),
         ),
     ],
@@ -63,6 +91,12 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
 def test_parse_trade_command_success(command: str, expected: ParsedOrder) -> None:
     parsed = parse_trade_command(command)
     assert parsed.model_dump() == expected.model_dump()
+
+
+def test_parse_trade_command_detects_quote_with_separator() -> None:
+    parsed = parse_trade_command("acheter 1 btc/usdt")
+    assert parsed.symbol == "BTCUSDT"
+    assert parsed.quote_asset == "USDT"
 
 
 def test_parse_trade_command_requires_symbol() -> None:
@@ -78,3 +112,8 @@ def test_parse_trade_command_rejects_negative_quantity() -> None:
 def test_parse_trade_command_limit_requires_price() -> None:
     with pytest.raises(CommandParsingError):
         parse_trade_command("vendre 2 eth usdt limit")
+
+
+def test_parse_trade_command_trailing_requires_callback() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("achetez 1 btcusdt trailing")


### PR DESCRIPTION
## Summary
- extend the command parser to recognize trailing stop keywords and capture callback/activation parameters
- send trailing-specific arguments to Binance when relaying parsed orders through the FastAPI endpoint
- add parser and API tests to cover trailing orders end-to-end

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d25bc99b188328b4fa335e5691af80