### PR TITLE
Support trailing stop metadata in parser

### DIFF
--- a/microserveur/command_parser.py
+++ b/microserveur/command_parser.py
@@ -18,6 +18,9 @@ class ParsedOrder:
     price: Optional[str] = None
     time_in_force: Optional[str] = None
     quote_asset: Optional[str] = None
+    quote: Optional[str] = None
+    callback: Optional[str] = None
+    activation_price: Optional[str] = None
 
     def dict(self) -> dict[str, Optional[str]]:
         return asdict(self)
@@ -68,7 +71,43 @@ ORDER_TYPE_KEYWORDS = {
     normalize_keyword(key): value for key, value in RAW_ORDER_TYPE_KEYWORDS.items()
 }
 
-ORDER_KEYWORDS = set(SIDE_KEYWORDS.keys()) | set(ORDER_TYPE_KEYWORDS.keys())
+RAW_CALLBACK_RATE_KEYWORDS = {
+    "callback",
+    "callback_rate",
+    "callbackrate",
+    "callback%",
+    "taux_callback",
+    "taux_de_callback",
+    "callback_pourcentage",
+}
+
+CALLBACK_RATE_KEYWORDS = {normalize_keyword(key) for key in RAW_CALLBACK_RATE_KEYWORDS}
+
+RAW_ACTIVATION_PRICE_KEYWORDS = {
+    "activation",
+    "activation_price",
+    "activationprice",
+    "prix_activation",
+    "prix_dactivation",
+    "activation_prix",
+    "trigger",
+    "trigger_price",
+    "triggerprice",
+    "prix_declenchement",
+    "prixdeclenchement",
+    "declenchement",
+}
+
+ACTIVATION_PRICE_KEYWORDS = {
+    normalize_keyword(key) for key in RAW_ACTIVATION_PRICE_KEYWORDS
+}
+
+ORDER_KEYWORDS = (
+    set(SIDE_KEYWORDS.keys())
+    | set(ORDER_TYPE_KEYWORDS.keys())
+    | CALLBACK_RATE_KEYWORDS
+    | ACTIVATION_PRICE_KEYWORDS
+)
 
 KNOWN_SYMBOL_SUFFIXES = {
     "USDT",
@@ -117,12 +156,16 @@ NUMBER_PATTERN = re.compile(r"(?<![A-Za-z0-9])[+-]?\d+(?:[.,]\d+)?(?![A-Za-z0-9]
 
 
 def extract_numbers(tokens: list[str]) -> list[Decimal]:
-    numbers = []
-    for token in tokens:
+    return [value for _, value in extract_numbers_with_indices(tokens)]
+
+
+def extract_numbers_with_indices(tokens: list[str]) -> list[tuple[int, Decimal]]:
+    numbers: list[tuple[int, Decimal]] = []
+    for index, token in enumerate(tokens):
         for match in NUMBER_PATTERN.finditer(token):
             normalized = match.group().replace(",", ".")
             try:
-                numbers.append(Decimal(normalized))
+                numbers.append((index, Decimal(normalized)))
             except InvalidOperation:
                 continue
     return numbers
@@ -181,21 +224,52 @@ def parse_trade_command(command: str) -> ParsedOrder:
     if not symbol:
         raise CommandParsingError("Impossible de déterminer le symbole à trader.")
 
-    numbers = extract_numbers(raw_tokens)
-    if not numbers:
+    numbers_with_indices = extract_numbers_with_indices(raw_tokens)
+    if not numbers_with_indices:
         raise CommandParsingError("Impossible de déterminer la quantité à trader.")
 
-    quantity = numbers[0]
+    quantity_index, quantity = numbers_with_indices[0]
     if quantity <= 0:
         raise CommandParsingError("La quantité doit être supérieure à zéro.")
 
+    used_number_indices = {quantity_index}
+
     price: Optional[Decimal] = None
+    price_index: Optional[int] = None
     if order_type == "LIMIT":
-        if len(numbers) < 2:
+        if len(numbers_with_indices) < 2:
             raise CommandParsingError("Une commande limite nécessite un prix.")
-        price = numbers[1]
+        price_index, price = numbers_with_indices[1]
         if price <= 0:
             raise CommandParsingError("Le prix doit être supérieur à zéro.")
+        used_number_indices.add(price_index)
+
+    def find_number_after_keywords(keywords: set[str]) -> Optional[Decimal]:
+        for idx, keyword in enumerate(keyword_tokens):
+            if keyword not in keywords:
+                continue
+            for token_index, value in numbers_with_indices:
+                if token_index in used_number_indices:
+                    continue
+                if token_index >= idx:
+                    used_number_indices.add(token_index)
+                    return value
+        return None
+
+    callback_value = find_number_after_keywords(CALLBACK_RATE_KEYWORDS)
+    if callback_value is not None and callback_value <= 0:
+        raise CommandParsingError("Le callback doit être supérieur à zéro.")
+
+    activation_value = find_number_after_keywords(ACTIVATION_PRICE_KEYWORDS)
+    if activation_value is not None and activation_value <= 0:
+        raise CommandParsingError("Le prix d'activation doit être supérieur à zéro.")
+
+    callback_str = decimal_to_str(callback_value) if callback_value is not None else None
+    activation_str = (
+        decimal_to_str(activation_value) if activation_value is not None else None
+    )
+
+    quote_asset = detect_quote_asset(symbol)
 
     return ParsedOrder(
         side=side,
@@ -204,7 +278,10 @@ def parse_trade_command(command: str) -> ParsedOrder:
         quantity=decimal_to_str(quantity),
         price=decimal_to_str(price) if price is not None else None,
         time_in_force="GTC" if order_type == "LIMIT" else None,
-        quote_asset=detect_quote_asset(symbol),
+        quote_asset=quote_asset,
+        quote=quote_asset,
+        callback=callback_str,
+        activation_price=activation_str,
     )
 
 

--- a/microserveur/main.py
+++ b/microserveur/main.py
@@ -106,6 +106,12 @@ def place_order(payload: CommandRequest):
         order_payload["timeInForce"] = parsed.time_in_force or "GTC"
         order_payload["price"] = parsed.price
 
+    if parsed.callback is not None:
+        order_payload["callbackRate"] = parsed.callback
+
+    if parsed.activation_price is not None:
+        order_payload["activationPrice"] = parsed.activation_price
+
     try:
         response = client.create_order(**order_payload)
     except (BinanceAPIException, BinanceRequestException) as exc:

--- a/microserveur/tests/test_parser.py
+++ b/microserveur/tests/test_parser.py
@@ -19,6 +19,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 order_type="MARKET",
                 quantity="0.1",
                 quote_asset="USDT",
+                quote="USDT",
             ),
         ),
         (
@@ -31,6 +32,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 price="2300",
                 time_in_force="GTC",
                 quote_asset="USDT",
+                quote="USDT",
             ),
         ),
         (
@@ -41,6 +43,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 order_type="MARKET",
                 quantity="5",
                 quote_asset="USDT",
+                quote="USDT",
             ),
         ),
         (
@@ -51,6 +54,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 order_type="MARKET",
                 quantity="1",
                 quote_asset="USDT",
+                quote="USDT",
             ),
         ),
         (
@@ -61,6 +65,7 @@ from command_parser import CommandParsingError, ParsedOrder, parse_trade_command
                 order_type="MARKET",
                 quantity="2",
                 quote_asset="USDT",
+                quote="USDT",
             ),
         ),
     ],
@@ -74,6 +79,7 @@ def test_parse_trade_command_detects_quote_with_separator() -> None:
     parsed = parse_trade_command("acheter 1 btc/usdt")
     assert parsed.symbol == "BTCUSDT"
     assert parsed.quote_asset == "USDT"
+    assert parsed.quote == "USDT"
 
 
 def test_parse_trade_command_requires_symbol() -> None:
@@ -89,3 +95,19 @@ def test_parse_trade_command_rejects_negative_quantity() -> None:
 def test_parse_trade_command_limit_requires_price() -> None:
     with pytest.raises(CommandParsingError):
         parse_trade_command("vendre 2 eth usdt limit")
+
+
+def test_parse_trade_command_extracts_callback_and_activation() -> None:
+    parsed = parse_trade_command("vend 3 btcusdt callback 1.5 activation 25000")
+    assert parsed.callback == "1.5"
+    assert parsed.activation_price == "25000"
+
+
+def test_parse_trade_command_rejects_negative_callback() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("acheter 1 btcusdt callback -1")
+
+
+def test_parse_trade_command_rejects_negative_activation_price() -> None:
+    with pytest.raises(CommandParsingError):
+        parse_trade_command("acheter 1 btcusdt activation -100")


### PR DESCRIPTION
## Summary
- extend ParsedOrder with quote alias plus callback and activation price fields
- detect callback rate and activation price keywords while parsing commands and validate their values
- include the optional metadata in the Binance payload and cover the new behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d263552b748328b892ee4beec643dd